### PR TITLE
Navigation from sign in page

### DIFF
--- a/web/pageObjects/discover.page.ts
+++ b/web/pageObjects/discover.page.ts
@@ -1,9 +1,9 @@
 import * as page from './page'
 
 
-const discoverPageTitle = '//h1[text()="Discover"]'
+const discoverPageTitle = 'h1'
 
 
-export async function getDiscoverPageTitle(): Promise <boolean> {
-    return await page.elementPresentByLocator(discoverPageTitle)
+export async function getDiscoverPageTitleText(): Promise<string> {
+    return await page.getElementTextByLocator(discoverPageTitle)
 }

--- a/web/pageObjects/resetPass.page.ts
+++ b/web/pageObjects/resetPass.page.ts
@@ -1,0 +1,9 @@
+import * as page from "./page"
+
+
+const resetPassPageTitle = 'h1'
+
+
+export async function getResetPassPageTitleText(): Promise<string> {
+    return await page.getElementTextByLocator(resetPassPageTitle)
+}

--- a/web/pageObjects/signIn.page.ts
+++ b/web/pageObjects/signIn.page.ts
@@ -2,9 +2,14 @@ import * as page from "./page"
 
 
 const signInPageTitle = 'h1'
+
 const emailInput = '//input[@placeholder = "Email"]'
 const passInput = '//input[@name="password"]'
+
 const signInBtn = '//button[text()="Sign in"]'
+const createAccBtn = '//a[@href="/sign-up"]'
+const forgotPassBtn = '//a[@href="/reset-password"]'
+
 const backendFormValidationError = '//form/div/h3'
 const frontendEmailValidationError = '//div[./input[@name="email"]]//h3'
 const frontendPasswordValidationError = '//div[./input[@name="password"]]//h3'
@@ -16,6 +21,14 @@ export async function openSignInPage(): Promise<void> {
 
 export async function clickSignInBtn(): Promise<void> {
     await page.clickByLocator(signInBtn)
+}
+
+export async function clickCreateAccBtn(): Promise<void> {
+    await page.clickByLocator(createAccBtn)
+}
+
+export async function clickForgotPassBtn(): Promise<void> {
+    await page.clickByLocator(forgotPassBtn)
 }
 
 export async function signInWithEmail(email: string, pass: string): Promise<void> {

--- a/web/pageObjects/signUp.page.ts
+++ b/web/pageObjects/signUp.page.ts
@@ -1,0 +1,9 @@
+import * as page from "./page"
+
+
+const signUpPageTitle = 'h1'
+
+
+export async function getSignUpPageTitleText(): Promise<string> {
+    return await page.getElementTextByLocator(signUpPageTitle)
+}

--- a/web/tests/signInEmail-e2e.ts
+++ b/web/tests/signInEmail-e2e.ts
@@ -29,6 +29,7 @@ describe('Sign in with email from sign up page', () => {
 
     it('Success sign in', async () => {
         await signInPage.signInWithEmail(email, pass)
+        await browser.pause(2000)
         expect (await discoverPage.getDiscoverPageTitleText()).equals('Discover')
     })
 

--- a/web/tests/signInEmail-e2e.ts
+++ b/web/tests/signInEmail-e2e.ts
@@ -29,7 +29,7 @@ describe('Sign in with email from sign up page', () => {
 
     it('Success sign in', async () => {
         await signInPage.signInWithEmail(email, pass)
-        expect (await discoverPage.getDiscoverPageTitle()).to.be.true
+        expect (await discoverPage.getDiscoverPageTitleText()).equals('Discover')
     })
 
     it('Attempt to sign in with invalid password', async() => {

--- a/web/tests/signInEmail-e2e.ts
+++ b/web/tests/signInEmail-e2e.ts
@@ -66,12 +66,12 @@ describe('Sign in with email from sign up page', () => {
         expect (await signInPage.getPassValidationErrorText()).equals(requiredValidationErrorText)
     })
 
-    it('Open sign up page from sign in screen', async () => {
+    it('Open sign up page from sign in page', async () => {
         await signInPage.clickCreateAccBtn()
         expect(await signUpPage.getSignUpPageTitleText()).equals('Register')
     })
 
-    it('Open reset password page from sign in screen', async () => {
+    it('Open reset password page from sign in page', async () => {
         await signInPage.clickForgotPassBtn()
         expect(await resetPassPage.getResetPassPageTitleText()).equals('Reset your password')
     })

--- a/web/tests/signInEmail-e2e.ts
+++ b/web/tests/signInEmail-e2e.ts
@@ -36,13 +36,11 @@ describe('Sign in with email from sign up page', () => {
     it('Attempt to sign in with invalid password', async() => {
         await signInPage.signInWithEmail(email, invalidPass)
         browser.pause(2000)
-        expect (await signInPage.getSignInPageTitleText()).equals('Sign in')
         expect (await signInPage.getIncorrectCredentialsErrorText()).equals(incorrectCredentialsErrorText)
     })
 
     it('Attempt to sign in with non registered email', async() => {
         await signInPage.signInWithEmail(unregistredEmail, invalidPass)
-        expect (await signInPage.getSignInPageTitleText()).equals('Sign in')
         expect (await signInPage.getIncorrectCredentialsErrorText()).equals(incorrectCredentialsErrorText)
     })
 

--- a/web/tests/signInEmail-e2e.ts
+++ b/web/tests/signInEmail-e2e.ts
@@ -1,5 +1,7 @@
 import * as signInPage from "../pageObjects/signIn.page"
 import * as discoverPage from "../pageObjects/discover.page"
+import * as signUpPage from "../pageObjects/signUp.page"
+import * as resetPassPage from "../pageObjects/resetPass.page"
 import { expect } from 'chai'
 
 
@@ -65,5 +67,14 @@ describe('Sign in with email from sign up page', () => {
         expect (await signInPage.getPassValidationErrorText()).equals(requiredValidationErrorText)
     })
 
+    it('Open sign up page from sign in screen', async () => {
+        await signInPage.clickCreateAccBtn()
+        expect(await signUpPage.getSignUpPageTitleText()).equals('Register')
+    })
+
+    it('Open reset password page from sign in screen', async () => {
+        await signInPage.clickForgotPassBtn()
+        expect(await resetPassPage.getResetPassPageTitleText()).equals('Reset your password')
+    })
 
 })


### PR DESCRIPTION
Additional tests for navigation from sign in page to 
* sign up page
* forgot password page

For that  new page objects created
* sign up page
* forgot password page


Change assertion for success login case 